### PR TITLE
Update rust feedstock to 1.24.0

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,5 @@
 BSD 3-clause license
-Copyright (c) 2015-2017, conda-forge
+Copyright (c) 2015-2018, conda-forge
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,3 +1,6 @@
 #!/bin/bash -e
 
+unset REQUESTS_CA_BUNDLE
+unset SSL_CERT_FILE
+
 ./install.sh --prefix=$PREFIX

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,6 +1,3 @@
 #!/bin/bash -e
 
-unset REQUESTS_CA_BUNDLE
-unset SSL_CERT_FILE
-
 ./install.sh --prefix=$PREFIX

--- a/recipe/forge_test.sh
+++ b/recipe/forge_test.sh
@@ -1,0 +1,13 @@
+#!/bin/bash -e -x
+
+## TODO: remove the following `unset` lines, once the following issue in `conda-build` is resolved:
+##       <https://github.com/conda/conda-build/issues/2255>
+
+unset REQUESTS_CA_BUNDLE
+unset SSL_CERT_FILE
+
+rustc --help
+rustdoc --help
+cargo --help
+cargo install xsv
+

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.21.0" %}
+{% set version = "1.24.0" %}
 
 package:
   name: rust
@@ -7,11 +7,11 @@ package:
 source:
   url: https://static.rust-lang.org/dist/rust-{{ version }}-x86_64-unknown-linux-gnu.tar.gz  # [linux]
   url: https://static.rust-lang.org/dist/rust-{{ version }}-x86_64-apple-darwin.tar.gz       # [osx]
-  sha256: b41e70e018402bc04d02fde82f91bea24428e6be432f0df12ac400cfb03108e8                   # [linux]
-  sha256: 75a7f4bd7c72948030bb9e421df27e8a650dea826fb5b836cf59d23d6f985a0d                   # [osx]
+  sha256: 336cf7af6c857cdaa110e1425719fa3a1652351098dc73f156e5bf02ed86443c                   # [linux]
+  sha256: 1aecba7cab4bc1a9e0e931c04aa00849e930b567d243da7b676ede8f527a2992                   # [osx]
 
 build:
-  number: 1
+  number: 0
   skip: true  # [win]
   # the distributed binaries are already relocatable
   binary_relocation: False
@@ -37,3 +37,4 @@ extra:
     - johanneskoester
     - abhi18av
     - pkgw
+    - dlaehnemann

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,7 +18,7 @@ build:
 
 test:
   files: 
-    - test_forge.sh
+    - forge_test.sh
   commands:
     - time bash ./forge_test.sh  # [not win]
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,11 +17,10 @@ build:
   binary_relocation: False
 
 test:
+  files: 
+    - test_forge.sh
   commands:
-    - rustc --help
-    - rustdoc --help
-    - cargo --help
-    - cargo install xsv
+    - time bash ./forge_test.sh  # [not win]
 
 about:
   home: https://www.rust-lang.org


### PR DESCRIPTION
* bumps up the version number
* updates sha256 hashes
* resets build number
* adds maintainer
* updates LICENSE to 2018