### PR TITLE
Add a dev label for nightly releases

### DIFF
--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -17,59 +17,10 @@ jobs:
   steps:
   # TODO: Fast finish on azure pipelines?
   - script: |
-      echo "Fast Finish"
-      
-
-  - bash: |
-      echo "##vso[task.prependpath]$CONDA/bin"
-      sudo chown -R $USER $CONDA
-    displayName: Add conda to PATH
-
-  - script: |
-      source activate base
-      conda install -n base -c conda-forge --quiet --yes conda-forge-ci-setup=2 conda-build
-    displayName: 'Add conda-forge-ci-setup=2'
-
-  - script: |
-      echo "Mangling homebrew from Azure to avoid conflicts."
-      source activate base
-      /usr/bin/sudo mangle_homebrew
-      /usr/bin/sudo -k
-    displayName: Mangle homebrew
-
-  - script: |
-      source activate base
-      echo "Configuring conda."
-
-      setup_conda_rc ./ "./recipe" ./.ci_support/${CONFIG}.yaml
       export CI=azure
-      source run_conda_forge_build_setup
-      conda update --yes --quiet --override-channels -c conda-forge -c defaults --all
-    env: {
-      OSX_FORCE_SDK_DOWNLOAD: "1"
-    }
-    displayName: Configure conda and conda-build
-
-  - script: |
-      source activate base
-      mangle_compiler ./ "./recipe" ./.ci_support/${CONFIG}.yaml
-    displayName: Mangle compiler
-
-  - script: |
-      source activate base
-      make_build_number ./ "./recipe" ./.ci_support/${CONFIG}.yaml
-    displayName: Generate build number clobber file
-
-  - script: |
-      source activate base
-      conda build "./recipe" -m ./.ci_support/${CONFIG}.yaml --clobber-file ./.ci_support/clobber_${CONFIG}.yaml
-    displayName: Build recipe
-
-  - script: |
-      source activate base
+      export OSX_FORCE_SDK_DOWNLOAD="1"
       export GIT_BRANCH=$BUILD_SOURCEBRANCHNAME
-      upload_package ./ "./recipe" ./.ci_support/${CONFIG}.yaml
-    displayName: Upload package
+      ./.scripts/run_osx_build.sh
+    displayName: Run OSX build
     env:
       BINSTAR_TOKEN: $(BINSTAR_TOKEN)
-    condition: and(succeeded(), not(eq(variables['UPLOAD_PACKAGES'], 'False')))

--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -56,15 +56,19 @@ jobs:
 
     - task: CondaEnvironment@1
       inputs:
-        packageSpecs: 'python=3.6 conda-build conda conda-forge::conda-forge-ci-setup=2' # Optional
+        packageSpecs: 'python=3.6 conda-build conda conda-forge::conda-forge-ci-setup=3 pip' # Optional
         installOptions: "-c conda-forge"
         updateConda: true
       displayName: Install conda-build and activate environment
 
     - script: set PYTHONUNBUFFERED=1
+      displayName: Set PYTHONUNBUFFERED
 
     # Configure the VM
-    - script: setup_conda_rc .\ ".\recipe" .\.ci_support\%CONFIG%.yaml
+    - script: |
+        call activate base
+        setup_conda_rc .\ ".\recipe" .\.ci_support\%CONFIG%.yaml
+      displayName: conda-forge CI setup
 
     # Configure the VM.
     - script: |
@@ -95,7 +99,7 @@ jobs:
     - script: |
         set "GIT_BRANCH=%BUILD_SOURCEBRANCHNAME%"
         call activate base
-        upload_package .\ ".\recipe" .ci_support\%CONFIG%.yaml
+        upload_package  .\ ".\recipe" .ci_support\%CONFIG%.yaml
       displayName: Upload package
       env:
         BINSTAR_TOKEN: $(BINSTAR_TOKEN)

--- a/.drone.yml
+++ b/.drone.yml
@@ -13,7 +13,7 @@ steps:
     CONFIG: linux_aarch64_
     UPLOAD_PACKAGES: True
     PLATFORM: linux-aarch64
-    BINSTAR_TOKEN: 
+    BINSTAR_TOKEN:
       from_secret: BINSTAR_TOKEN
   commands:
     - export FEEDSTOCK_ROOT="$DRONE_WORKSPACE"

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @abhi18av @dlaehnemann @johanneskoester @pkgw
+* @abhi18av @andfoy @dlaehnemann @johanneskoester @pkgw

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -19,7 +19,8 @@ conda-build:
 
 CONDARC
 
-conda install --yes --quiet conda-forge-ci-setup=2 conda-build -c conda-forge
+conda install --yes --quiet conda-forge-ci-setup=3 conda-build pip -c conda-forge
+
 
 # set up the condarc
 setup_conda_rc "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
@@ -33,7 +34,7 @@ conda build "${RECIPE_ROOT}" -m "${CI_SUPPORT}/${CONFIG}.yaml" \
     --clobber-file "${CI_SUPPORT}/clobber_${CONFIG}.yaml"
 
 if [[ "${UPLOAD_PACKAGES}" != "False" ]]; then
-    upload_package "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
+    upload_package  "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
 fi
 
 touch "${FEEDSTOCK_ROOT}/build_artifacts/conda-forge-build-done-${CONFIG}"

--- a/.scripts/run_osx_build.sh
+++ b/.scripts/run_osx_build.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+
+set -x
+
+echo -e "\n\nInstalling a fresh version of Miniforge."
+if [[ ${CI} == "travis" ]]; then
+  echo -en 'travis_fold:start:install_miniforge\\r'
+fi
+MINIFORGE_URL="https://github.com/conda-forge/miniforge/releases/latest/download"
+MINIFORGE_FILE="Miniforge3-MacOSX-x86_64.sh"
+curl -L -O "${MINIFORGE_URL}/${MINIFORGE_FILE}"
+bash $MINIFORGE_FILE -b
+if [[ ${CI} == "travis" ]]; then
+  echo -en 'travis_fold:end:install_miniforge\\r'
+fi
+
+echo -e "\n\nConfiguring conda."
+if [[ ${CI} == "travis" ]]; then
+  echo -en 'travis_fold:start:configure_conda\\r'
+fi
+
+source ${HOME}/miniforge3/etc/profile.d/conda.sh
+conda activate base
+
+echo -e "\n\nInstalling conda-forge-ci-setup=3 and conda-build."
+conda install -n base --quiet --yes conda-forge-ci-setup=3 conda-build pip
+
+
+
+echo -e "\n\nSetting up the condarc and mangling the compiler."
+setup_conda_rc ./ ./recipe ./.ci_support/${CONFIG}.yaml
+mangle_compiler ./ ./recipe .ci_support/${CONFIG}.yaml
+
+echo -e "\n\nMangling homebrew in the CI to avoid conflicts."
+/usr/bin/sudo mangle_homebrew
+/usr/bin/sudo -k
+
+echo -e "\n\nRunning the build setup script."
+source run_conda_forge_build_setup
+
+
+if [[ ${CI} == "travis" ]]; then
+  echo -en 'travis_fold:end:configure_conda\\r'
+fi
+
+set -e
+
+echo -e "\n\nMaking the build clobber file and running the build."
+make_build_number ./ ./recipe ./.ci_support/${CONFIG}.yaml
+conda build ./recipe -m ./.ci_support/${CONFIG}.yaml --clobber-file ./.ci_support/clobber_${CONFIG}.yaml
+
+if [[ "${UPLOAD_PACKAGES}" != "False" ]]; then
+  echo -e "\n\nUploading the packages."
+  upload_package  ./ ./recipe ./.ci_support/${CONFIG}.yaml
+fi

--- a/README.md
+++ b/README.md
@@ -180,6 +180,7 @@ Feedstock Maintainers
 =====================
 
 * [@abhi18av](https://github.com/abhi18av/)
+* [@andfoy](https://github.com/andfoy/)
 * [@dlaehnemann](https://github.com/dlaehnemann/)
 * [@johanneskoester](https://github.com/johanneskoester/)
 * [@pkgw](https://github.com/pkgw/)


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

Fixes #31

This PR enables conda-forge to build nightly versions of Rust, however, this PR must be merged against a new branch ``dev`` according to [CFEP-05](https://github.com/conda-forge/cfep/blob/master/cfep-05.md). I would appreciate if any @conda-forge/rust maintainers could help creating that branch