### PR TITLE
Add missing zlib run dep

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -5,11 +5,14 @@ c_compiler_version:
 cdt_name:
 - cos6
 channel_sources:
-- conda-forge,defaults
+- conda-forge
 channel_targets:
 - conda-forge main
 docker_image:
 - quay.io/condaforge/linux-anvil-comp7
+pin_run_as_build:
+  zlib:
+    max_pin: x.x
 rust_arch:
 - x86_64-unknown-linux-gnu
 target_platform:
@@ -17,3 +20,5 @@ target_platform:
 zip_keys:
 - - cdt_name
   - docker_image
+zlib:
+- '1.2'

--- a/.ci_support/linux_aarch64_.yaml
+++ b/.ci_support/linux_aarch64_.yaml
@@ -14,7 +14,12 @@ channel_targets:
 - conda-forge main
 docker_image:
 - quay.io/condaforge/linux-anvil-aarch64
+pin_run_as_build:
+  zlib:
+    max_pin: x.x
 rust_arch:
 - aarch64-unknown-linux-gnu
 target_platform:
 - linux-aarch64
+zlib:
+- '1.2'

--- a/.ci_support/linux_ppc64le_.yaml
+++ b/.ci_support/linux_ppc64le_.yaml
@@ -5,12 +5,17 @@ c_compiler_version:
 cdt_name:
 - cos7
 channel_sources:
-- conda-forge,defaults
+- conda-forge
 channel_targets:
 - conda-forge main
 docker_image:
 - quay.io/condaforge/linux-anvil-ppc64le
+pin_run_as_build:
+  zlib:
+    max_pin: x.x
 rust_arch:
 - powerpc64le-unknown-linux-gnu
 target_platform:
 - linux-ppc64le
+zlib:
+- '1.2'

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -1,13 +1,11 @@
 MACOSX_DEPLOYMENT_TARGET:
 - '10.9'
 channel_sources:
-- conda-forge,defaults
+- conda-forge
 channel_targets:
 - conda-forge main
 macos_machine:
 - x86_64-apple-darwin13.4.0
-rust:
-- '1.46'
 rust_arch:
 - x86_64-apple-darwin
 target_platform:

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -1,7 +1,7 @@
 MACOSX_DEPLOYMENT_TARGET:
 - '11.0'
 channel_sources:
-- conda-forge/label/rust_dev,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 macos_machine:

--- a/.ci_support/win_64_.yaml
+++ b/.ci_support/win_64_.yaml
@@ -1,5 +1,5 @@
 channel_sources:
-- conda-forge,defaults
+- conda-forge
 channel_targets:
 - conda-forge main
 rust_arch:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,7 +21,7 @@ source:
     - 0001-gh-106-install.sh-Perfomance-Use-more-shell-builtins.diff
 
 build:
-  number: 2
+  number: 3
 
 requirements:
   build:
@@ -33,6 +33,13 @@ outputs:
     build:
       noarch: generic
       binary_relocation: false
+      missing_dso_whitelist:  # [linux]
+        - /lib64/librt.so.1  # [linux]
+        - /lib64/libdl.so.2  # [linux]
+        - /lib64/libpthread.so.0  # [linux]
+        - /lib64/libm.so.6  # [linux]
+        - /lib64/libc.so.6  # [linux]
+        - /lib64/ld-linux-x86-64.so.2  # [linux]
       merge_build_host: false
     requirements:
       build:
@@ -53,6 +60,16 @@ outputs:
     build:
       # the distributed binaries are already relocatable
       binary_relocation: false
+      missing_dso_whitelist:  # [linux]
+        - /lib64/librt.so.1  # [linux]
+        - /lib64/libdl.so.2  # [linux]
+        - /lib64/libpthread.so.0  # [linux]
+        - /lib64/libm.so.6  # [linux]
+        - /lib64/libc.so.6  # [linux]
+        - /lib64/ld-linux-x86-64.so.2  # [linux]
+        # Added as run deps: libgcc-ng (via compiler strong run_exports), zlib
+        # - /lib64/libgcc_s.so.1  # [linux]
+        # - /lib64/libz.so.1  # [linux]
     run_exports:
       strong_constrains:
         - __osx >={{ MACOSX_DEPLOYMENT_TARGET|default("10.9") }}  # [osx and x86_64]
@@ -62,6 +79,8 @@ outputs:
       host:
         - {{ pin_subpackage("rust-std-" ~ rust_arch, exact=True) }}
         - {{ compiler('c') }}  # [linux] -- rustc needs a toolchain to link executables
+        # zlib is linked by **/lib/libLLVM-*-rust-*.so
+        - zlib  # [linux]
       run:
         - {{ pin_subpackage("rust-std-" ~ rust_arch, exact=True) }}
         - gcc_impl_{{ target_platform }}  # [linux]


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->
(incidentally closes gh-92)

<!--
Please add any other relevant info below:
-->
Inspecting `conda-build`'s DSO warning logs we can see that `libgcc_s.so.1` and `libz.so.1` are linked to.
A runtime dependency for the former is added through the `{{ compiler('c') }}` in `requirements/host`.
The latter is used by the included binaries via `lib/librustc_driver-*.so -> lib/libLLVM-*-rust-*.so -> libz.so.1` and thus missing if it's not system provided.

(cc @tedil, this is the missing dep in `conda-forge::rust` itself I mentioned before)