### PR TITLE
[ci skip] adding user @xhochy

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @abhi18av @dlaehnemann @isuruf @johanneskoester @mbargull @pkgw
+* @xhochy @abhi18av @dlaehnemann @isuruf @johanneskoester @mbargull @pkgw

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -108,6 +108,7 @@ about:
 
 extra:
   recipe-maintainers:
+    - xhochy
     - johanneskoester
     - abhi18av
     - pkgw


### PR DESCRIPTION

Hi! This is the friendly automated conda-forge-webservice.

I've added user @xhochy as instructed in #105.

Merge this PR to add the user. Please do not rerender this PR or change it in any way. It has `[ci skip]` in the commit message to avoid pushing a new build and so the build configuration in the feedstock should not be changed.

Please contact [conda-forge/core](https://conda-forge.org/docs/maintainer/maintainer_faq.html#mfaq-contact-core) to have this PR merged, if the maintainer is unresponsive.

Fixes #105