### PR TITLE
Add iOS targets to the feedstock

### DIFF
--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -14,6 +14,12 @@ jobs:
       osx_arm64_:
         CONFIG: osx_arm64_
         UPLOAD_PACKAGES: 'True'
+      ios_64_:
+        CONFIG: ios_64_
+        UPLOAD_PACKAGES: 'True'
+      ios_aarch64_:
+        CONFIG: ios_aarch64_
+        UPLOAD_PACKAGES: 'True'
   timeoutInMinutes: 360
 
   steps:

--- a/.ci_support/ios_64_.yaml
+++ b/.ci_support/ios_64_.yaml
@@ -1,0 +1,12 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.9'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+macos_machine:
+- x86_64-apple-darwin13.4.0
+rust_arch:
+- x86_64-apple-ios
+target_platform:
+- osx-64

--- a/.ci_support/ios_aarch64_.yaml
+++ b/.ci_support/ios_aarch64_.yaml
@@ -1,0 +1,12 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.9'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+macos_machine:
+- arm64-apple-darwin20.0.0
+rust_arch:
+- aarch64-apple-ios
+target_platform:
+- osx-arm64

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,7 +1,9 @@
 rust_arch:
   - x86_64-unknown-linux-gnu    # [linux64]
   - aarch64-unknown-linux-gnu   # [aarch64]
-  - powerpc64le-unknown-linux-gnu       # [ppc64le]
+  - powerpc64le-unknown-linux-gnu # [ppc64le]
   - x86_64-pc-windows-msvc      # [win64]
   - x86_64-apple-darwin         # [osx and x86_64]
   - aarch64-apple-darwin        # [osx and arm64]
+  - aarch64-apple-ios           # [ios and aarch64]
+  - x86_64-apple-ios            # [ios and x86_64]

--- a/recipe/install-rust.sh
+++ b/recipe/install-rust.sh
@@ -21,6 +21,8 @@ case "$target_platform" in
     win-64) rust_env_arch=X86_64_PC_WINDOWS_MSVC ;;
     osx-64) rust_env_arch=X86_64_APPLE_DARWIN ;;
     osx-arm64) rust_env_arch=AARCH64_APPLE_DARWIN ;;
+    ios-64) rust_env_arch=X86_64_APPLE_IOS ;;
+    ios-aarch64) rust_env_arch=AARCH64_APPLE_IOS ;;
     *) echo "unknown target_platform $target_platform" ; exit 1 ;;
 esac
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,20 +8,20 @@ source:
   url: https://static.rust-lang.org/dist/rust-{{ version }}-x86_64-unknown-linux-gnu.tar.gz  # [linux and x86_64]
   url: https://static.rust-lang.org/dist/rust-{{ version }}-aarch64-unknown-linux-gnu.tar.gz  # [aarch64]
   url: https://static.rust-lang.org/dist/rust-{{ version }}-powerpc64le-unknown-linux-gnu.tar.gz  # [ppc64le]
-  url: https://static.rust-lang.org/dist/rust-{{ version }}-x86_64-apple-darwin.tar.gz  # [osx and x86_64]
-  url: https://static.rust-lang.org/dist/rust-{{ version }}-aarch64-apple-darwin.tar.gz  # [osx and arm64]
   url: https://static.rust-lang.org/dist/rust-{{ version }}-x86_64-pc-windows-msvc.tar.gz  # [win64]
+  url: https://static.rust-lang.org/dist/rust-std-{{ version }}-aarch64-apple-ios.tar.gz  # [ios and aarch64]
+  url: https://static.rust-lang.org/dist/rust-std-{{ version }}-x86_64-apple-ios.tar.gz  # [ios and x86_64]
   sha256: 652a8966436c4e97b127721d9130810e1cdc8dfdf526fad68c9c1f6281bd02a3  # [linux and x86_64]
   sha256: 8edee248eed4b17c09b3d7b0096944b7e5992dd1119a28429c0b6b4d39a9613c  # [aarch64]
   sha256: 1d4d8b75c72362bb6e02bf56b53af9287806c4ef08187b8d166af0557a7c0096  # [ppc64le]
-  sha256: 020702c9564f53e18ac880db77c2f6b660a24ea372e4fda3f0c1ef2f8b9c74b9  # [osx and x86_64]
-  sha256: 8b07560267ec85703a5a9397a1746170fd7013e29fcfb9ffb8daa9bbf1e3211a  # [osx and arm64]
   sha256: 46916aca06f5cfaf17c41642ac9197cd3a877e89300a95b18c41b50619a72887  # [win64]
+  sha256: d61837407fec6ae6c9e4d9cc253b2dc6c336d6a6fb5d85119e4bbac49031521e  # [ios and aarch64]
+  sha256: eeab853aa1e77f1f1932e18bee16e4134da79c74bc2bc0ae80150d4fe5e6a606  # [ios and x86_64]
   patches:
     - 0001-gh-106-install.sh-Perfomance-Use-more-shell-builtins.diff
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:


### PR DESCRIPTION
Hi folks! I work over at the [Mozilla VPN project](https://github.com/mozilla-mobile/mozilla-vpn-client) and we started to use conda recently. In order to build our application for iOS we need to add this targets to the feedstock.

I would be happy to help out as a maintainer on this feedstock to support the new targets if necessary (we will soon also need to add Android targets as well). Let me know, thanks!

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] ~Reset the build number to `0` (if the version changed)~
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.