### PR TITLE
Add rust-std subpackages for iOS development

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '11'
+- '12'
 cdt_name:
 - cos6
 channel_sources:
@@ -12,6 +12,10 @@ docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 rust_arch:
 - x86_64-unknown-linux-gnu
+rust_std_extra:
+- aarch64-apple-ios
+- aarch64-apple-ios-sim
+- x86_64-apple-ios
 target_platform:
 - linux-64
 zlib:

--- a/.ci_support/linux_aarch64_.yaml
+++ b/.ci_support/linux_aarch64_.yaml
@@ -3,7 +3,7 @@ BUILD:
 c_compiler:
 - gcc
 c_compiler_version:
-- '11'
+- '12'
 cdt_arch:
 - aarch64
 cdt_name:

--- a/.ci_support/linux_ppc64le_.yaml
+++ b/.ci_support/linux_ppc64le_.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '11'
+- '12'
 cdt_name:
 - cos7
 channel_sources:

--- a/README.md
+++ b/README.md
@@ -89,6 +89,9 @@ Current release info
 | --- | --- | --- | --- |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-rust-green.svg)](https://anaconda.org/conda-forge/rust) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/rust.svg)](https://anaconda.org/conda-forge/rust) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/rust.svg)](https://anaconda.org/conda-forge/rust) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/rust.svg)](https://anaconda.org/conda-forge/rust) |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-rust--src-green.svg)](https://anaconda.org/conda-forge/rust-src) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/rust-src.svg)](https://anaconda.org/conda-forge/rust-src) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/rust-src.svg)](https://anaconda.org/conda-forge/rust-src) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/rust-src.svg)](https://anaconda.org/conda-forge/rust-src) |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-rust--std--aarch64--apple--ios-green.svg)](https://anaconda.org/conda-forge/rust-std-aarch64-apple-ios) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/rust-std-aarch64-apple-ios.svg)](https://anaconda.org/conda-forge/rust-std-aarch64-apple-ios) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/rust-std-aarch64-apple-ios.svg)](https://anaconda.org/conda-forge/rust-std-aarch64-apple-ios) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/rust-std-aarch64-apple-ios.svg)](https://anaconda.org/conda-forge/rust-std-aarch64-apple-ios) |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-rust--std--aarch64--apple--ios--sim-green.svg)](https://anaconda.org/conda-forge/rust-std-aarch64-apple-ios-sim) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/rust-std-aarch64-apple-ios-sim.svg)](https://anaconda.org/conda-forge/rust-std-aarch64-apple-ios-sim) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/rust-std-aarch64-apple-ios-sim.svg)](https://anaconda.org/conda-forge/rust-std-aarch64-apple-ios-sim) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/rust-std-aarch64-apple-ios-sim.svg)](https://anaconda.org/conda-forge/rust-std-aarch64-apple-ios-sim) |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-rust--std--x86_64--apple--ios-green.svg)](https://anaconda.org/conda-forge/rust-std-x86_64-apple-ios) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/rust-std-x86_64-apple-ios.svg)](https://anaconda.org/conda-forge/rust-std-x86_64-apple-ios) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/rust-std-x86_64-apple-ios.svg)](https://anaconda.org/conda-forge/rust-std-x86_64-apple-ios) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/rust-std-x86_64-apple-ios.svg)](https://anaconda.org/conda-forge/rust-std-x86_64-apple-ios) |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-rust--std--x86_64--unknown--linux--gnu-green.svg)](https://anaconda.org/conda-forge/rust-std-x86_64-unknown-linux-gnu) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/rust-std-x86_64-unknown-linux-gnu.svg)](https://anaconda.org/conda-forge/rust-std-x86_64-unknown-linux-gnu) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/rust-std-x86_64-unknown-linux-gnu.svg)](https://anaconda.org/conda-forge/rust-std-x86_64-unknown-linux-gnu) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/rust-std-x86_64-unknown-linux-gnu.svg)](https://anaconda.org/conda-forge/rust-std-x86_64-unknown-linux-gnu) |
 
 Installing rust-split
@@ -101,16 +104,16 @@ conda config --add channels conda-forge
 conda config --set channel_priority strict
 ```
 
-Once the `conda-forge` channel has been enabled, `rust, rust-src, rust-std-x86_64-unknown-linux-gnu` can be installed with `conda`:
+Once the `conda-forge` channel has been enabled, `rust, rust-src, rust-std-aarch64-apple-ios, rust-std-aarch64-apple-ios-sim, rust-std-x86_64-apple-ios, rust-std-x86_64-unknown-linux-gnu` can be installed with `conda`:
 
 ```
-conda install rust rust-src rust-std-x86_64-unknown-linux-gnu
+conda install rust rust-src rust-std-aarch64-apple-ios rust-std-aarch64-apple-ios-sim rust-std-x86_64-apple-ios rust-std-x86_64-unknown-linux-gnu
 ```
 
 or with `mamba`:
 
 ```
-mamba install rust rust-src rust-std-x86_64-unknown-linux-gnu
+mamba install rust rust-src rust-std-aarch64-apple-ios rust-std-aarch64-apple-ios-sim rust-std-x86_64-apple-ios rust-std-x86_64-unknown-linux-gnu
 ```
 
 It is possible to list all of the versions of `rust` available on your platform with `conda`:

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -7,6 +7,6 @@ rust_arch:
   - aarch64-apple-darwin        # [osx and arm64]
 
 rust_std_extra:
-  - aarch64-apple-ios           # [osx]
-  - x86_64-apple-ios            # [osx]
-  - aarch64-apple-ios-sim       # [osx]
+  - aarch64-apple-ios
+  - x86_64-apple-ios
+  - aarch64-apple-ios-sim

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -5,3 +5,8 @@ rust_arch:
   - x86_64-pc-windows-msvc      # [win64]
   - x86_64-apple-darwin         # [osx and x86_64]
   - aarch64-apple-darwin        # [osx and arm64]
+
+rust_std_extra:
+  - aarch64-apple-ios
+  - x86_64-apple-ios
+  - aarch64-apple-ios

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -7,6 +7,6 @@ rust_arch:
   - aarch64-apple-darwin        # [osx and arm64]
 
 rust_std_extra:
-  - aarch64-apple-ios
-  - x86_64-apple-ios
-  - aarch64-apple-ios
+  - aarch64-apple-ios           # [osx]
+  - x86_64-apple-ios            # [osx]
+  - aarch64-apple-ios-sim       # [osx]

--- a/recipe/install-rust-std-extra.sh
+++ b/recipe/install-rust-std-extra.sh
@@ -4,7 +4,7 @@ set -ex
 
 cd rust-std
 
-echo $TOP_PKG_NAME > ./components
+echo $PKG_NAME > ./components
 
 ./install.sh --prefix="$PREFIX" --destdir="$DESTDIR"
 

--- a/recipe/install-rust-std-extra.sh
+++ b/recipe/install-rust-std-extra.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -ex
+
+cd rust-std
+
+echo $TOP_PKG_NAME > ./components
+
+./install.sh --prefix="$PREFIX" --destdir="$DESTDIR"
+
+rm "${PREFIX}"/lib/rustlib/components
+rm "${PREFIX}"/lib/rustlib/install.log
+rm "${PREFIX}"/lib/rustlib/rust-installer-version
+rm "${PREFIX}"/lib/rustlib/uninstall.sh

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -132,7 +132,7 @@ outputs:
     requirements:
       run_constrained:
         # Having different versions of rust-std and rust is confusing.
-        - {{ pin_subpackage("rust", exact=True) }}
+        - {{ pin_subpackage("rust") }}
     test:
       commands:
         - test -d $PREFIX/lib/rustlib/{{ rust_std_extra }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,9 +23,18 @@ source:
   - url: https://static.rust-lang.org/dist/rust-src-{{ version }}.tar.gz
     sha256: 3cb12c47250fb9bd1d87e9f60a6247403eb3fc17c6fc226a95c2d298824ee5fd
     folder: rust-src
+  - url: https://static.rust-lang.org/dist/rust-std-{{ version }}-aarch64-apple-ios.tar.gz
+    sha256: ef1a7dc02df8cbb0b22e897253cd22b7de33e7958031604bc9d0a8fb9fd6c9a8
+    folder: rust-std
+  - url: https://static.rust-lang.org/dist/rust-std-{{ version }}-x86_64-apple-ios.tar.gz
+    sha256: 882a02c1fedff14cb4f7f09bd588386ab3f63e6b33fbf5ad5587af33886a9b51
+    folder: rust-std
+  - url: https://static.rust-lang.org/dist/rust-std-{{ version }}-aarch64-apple-ios-sim.tar.gz
+    sha256: 2291ac2949ca832ea6db3795f17e981d7c563fa5b102eaea39811482320374b2
+    folder: rust-std
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:
@@ -114,6 +123,23 @@ outputs:
         - test -f "${PREFIX}"/lib/rustlib/src/rust/Cargo.lock
         # Make sure that the outputs do not clobber with other rust components
         - test "$(ls "${PREFIX}"/lib/rustlib/)" = "$(printf "manifest-rust-src\nsrc")"
+
+  - name: rust-std-{{ rust_std_extra }}
+    build:
+      noarch: generic
+      binary_relocation: false
+    requirements:
+      build:
+        - posix  # [win]
+      host:
+      run:
+    script: install-rust-std-extra.sh  # [unix]
+    script: install-rust-std-extra.bat  # [win]
+    test:
+      commands:
+        - test -d $PREFIX/lib/rustlib   # [unix]
+        - if not exist %LIBRARY_PREFIX%/lib/rustlib exit 1  # [win]
+        - echo {{ rust_std_extra }}
 
 about:
   home: https://www.rust-lang.org

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -125,20 +125,20 @@ outputs:
         - test "$(ls "${PREFIX}"/lib/rustlib/)" = "$(printf "manifest-rust-src\nsrc")"
 
   - name: rust-std-{{ rust_std_extra }}
+    script: install-rust-std-extra.sh
     build:
       noarch: generic
-      binary_relocation: false
+      skip: true  # [win]
     requirements:
-      build:
-        - posix  # [win]
-      host:
-      run:
-    script: install-rust-std-extra.sh  # [unix]
-    script: install-rust-std-extra.bat  # [win]
+      run_constrained:
+        # Having different versions of rust-std and rust is confusing.
+        - {{ pin_subpackage("rust", exact=True) }}
     test:
       commands:
-        - test -d $PREFIX/lib/rustlib   # [unix]
-        - if not exist %LIBRARY_PREFIX%/lib/rustlib exit 1  # [win]
+        - test -d $PREFIX/lib/rustlib/{{ rust_std_extra }}
+        - test -f $PREFIX/lib/rustlib/manifest-rust-std-{{ rust_std_extra }}
+        # Make sure that the outputs do not clobber with other rust components
+        - test -z "$(ls "${PREFIX}"/lib/rustlib/ | grep -v {{ rust_std_extra }})"
         - echo {{ rust_std_extra }}
 
 about:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -128,7 +128,7 @@ outputs:
     script: install-rust-std-extra.sh
     build:
       noarch: generic
-      skip: true  # [win]
+      skip: {{ rust_arch != "x86_64-unknown-linux-gnu" }}
     requirements:
       run_constrained:
         # Having different versions of rust-std and rust is confusing.


### PR DESCRIPTION
I'm working with the [Mozilla VPN](https://github.com/mozilla-mobile/mozilla-vpn-client) team and we are making another attempt to migrate our build infrastructure to use Conda for dependency management, and in order to get iOS builds working we would like to add the iOS rust targets to conda-forge.

This pull request should add recipes to download the `rust-std-<arch>-apple-ios` targets from [static.rust-lang.org](https://static.rust-lang.org) and install them alongside the `rust` package.

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [X] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] ~Ensured the license file is being packaged.~