### PR TITLE
Update subpackage pin versions for generic packages

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -107,7 +107,7 @@ outputs:
         - rustc --help
         - rustdoc --help
         - cargo --help
-        - cargo install --force xsv
+        - cargo --config net.git-fetch-with-cli=true install --force xsv
         - echo {{ rust_arch }}
 
   - name: rust-src

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -107,7 +107,7 @@ outputs:
         - rustc --help
         - rustdoc --help
         - cargo --help
-        - cargo --config 'registries.crates-io.protocol = "sparse"' install --force xsv
+        - cargo --config registries.crates-io.protocol=\"sparse\" install --force xsv
         - echo {{ rust_arch }}
 
   - name: rust-src

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -107,7 +107,7 @@ outputs:
         - rustc --help
         - rustdoc --help
         - cargo --help
-        - cargo --config net.git-fetch-with-cli=true install --force xsv
+        - cargo --config 'registries.crates-io.protocol = "sparse"' install --force xsv
         - echo {{ rust_arch }}
 
   - name: rust-src

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -117,7 +117,7 @@ outputs:
         # Having different versions of rust-src and rust is confusing.
         # `rust-src` is specific to the toolchain in `rustup`,
         # and we would like to keep that behavior.
-        - {{ pin_subpackage("rust", exact=True) }}
+        - {{ pin_subpackage("rust", min_pin="x.x.x", max_pin="x.x.x") }}
     test:
       commands:
         - test -f "${PREFIX}"/lib/rustlib/src/rust/Cargo.lock
@@ -132,7 +132,7 @@ outputs:
     requirements:
       run_constrained:
         # Having different versions of rust-std and rust is confusing.
-        - {{ pin_subpackage("rust") }}
+        - {{ pin_subpackage("rust", min_pin="x.x.x", max_pin="x.x.x") }}
     test:
       commands:
         - test -d $PREFIX/lib/rustlib/{{ rust_std_extra }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -59,6 +59,9 @@ outputs:
         - posix  # [win]
       host:
       run:
+      run_constrained:
+        # Having different versions of rust-std and rust is confusing.
+        - {{ pin_subpackage("rust", min_pin="x.x.x", max_pin="x.x.x") }}
     script: install-rust-std.sh  # [unix]
     script: install-rust-std.bat  # [win]
     test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,7 +34,7 @@ source:
     folder: rust-std
 
 build:
-  number: 1
+  number: 2
 
 requirements:
   build:


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->
Fixes: https://github.com/conda-forge/rust-feedstock/issues/124#issuecomment-1534931466

<!--
Please add any other relevant info below:
-->
[`pin_subpackage`](https://docs.conda.io/projects/conda-build/en/latest/resources/variants.html#referencing-subpackages) defaults to `min_pin='x.x.x.x.x.x` and `max_pin='x'`. `exact=True` also includes the build string, which limits the platform of the dependencies to the one used to build the generic package. Both are unintended.