### PR TITLE
Workaround conda-build detecting docs as sysroot

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -10,7 +10,7 @@ if errorlevel 1 exit 1
 
 @rem We need to delete the two directory as otherwise conda-build treats them as a sysroot
 @rem See https://github.com/conda/conda-build/blob/d3b717760f550abd58832c629d7f72aed46ae5ca/conda_build/post.py#L1376-L1381
-rmdir /s %LIBRARY_PREFIX%\share\doc\rust\html\src\sysroot
+rmdir /q /s %LIBRARY_PREFIX%\share\doc\rust\html\src\sysroot
 if errorlevel 1 exit 1
-rmdir /s %LIBRARY_PREFIX%\share\doc\rust\html\sysroot
+rmdir /q /s %LIBRARY_PREFIX%\share\doc\rust\html\sysroot
 if errorlevel 1 exit 1

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,3 +1,4 @@
+@echo on
 set MSYSTEM=MINGW%ARCH%
 set MSYS2_PATH_TYPE=inherit
 set CHERE_INVOKING=1

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -6,3 +6,10 @@ FOR /F "delims=" %%i in ('cygpath.exe -u "%SRC_DIR%"') DO set "SRC_DIR=%%i"
 copy "%RECIPE_DIR%\build.sh" .
 bash -lce "%SRC_DIR%/build.sh"
 if errorlevel 1 exit 1
+
+@rem We need to delete the two directory as otherwise conda-build treats them as a sysroot
+@rem See https://github.com/conda/conda-build/blob/d3b717760f550abd58832c629d7f72aed46ae5ca/conda_build/post.py#L1376-L1381
+rmdir /s %LIBRARY_PREFIX%\share\doc\rust\html\src\sysroot
+if errorlevel 1 exit 1
+rmdir /s %LIBRARY_PREFIX%\share\doc\rust\html\sysroot
+if errorlevel 1 exit 1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -56,7 +56,7 @@ source:
     folder: rust-std  # [(linux or win) and x86_64]
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

Discovered while working on https://github.com/conda-forge/pydantic-core-feedstock/pull/59