### PR TITLE
set run_exports on build

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -59,7 +59,7 @@ source:
     folder: rust-std  # [(linux or win) and x86_64]
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:
@@ -115,9 +115,9 @@ outputs:
         # Added as run deps: libgcc-ng (via compiler strong run_exports), zlib
         # - /lib64/libgcc_s.so.1  # [linux]
         # - /lib64/libz.so.1  # [linux]
-    run_exports:
-      strong_constrains:
-        - __osx >={{ MACOSX_DEPLOYMENT_TARGET|default("10.9") }}  # [osx and x86_64]
+      run_exports:
+        strong_constrains:
+          - __osx >={{ MACOSX_DEPLOYMENT_TARGET|default("10.9") }}  # [osx and x86_64]
     requirements:
       build:
         - posix  # [win]


### PR DESCRIPTION
run_exports on top-level still seems to work, despite not being quite right. Some tools like the cf-scripts don't seem to find these, though.