### PR TITLE
Add win-arm64 support

### DIFF
--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -11,6 +11,9 @@ jobs:
       win_64_:
         CONFIG: win_64_
         UPLOAD_PACKAGES: 'True'
+      win_arm64_:
+        CONFIG: win_arm64_
+        UPLOAD_PACKAGES: 'True'
   timeoutInMinutes: 360
   variables:
     CONDA_BLD_PATH: D:\\bld\\

--- a/.ci_support/win_arm64_.yaml
+++ b/.ci_support/win_arm64_.yaml
@@ -1,0 +1,8 @@
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+rust_arch:
+- aarch64-pc-windows-msvc
+target_platform:
+- win-arm64

--- a/README.md
+++ b/README.md
@@ -74,6 +74,13 @@ Current build status
                   <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/rust-feedstock?branchName=main&jobName=win&configuration=win%20win_64_" alt="variant">
                 </a>
               </td>
+            </tr><tr>
+              <td>win_arm64</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=4321&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/rust-feedstock?branchName=main&jobName=win&configuration=win%20win_arm64_" alt="variant">
+                </a>
+              </td>
             </tr>
           </tbody>
         </table>

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -1,4 +1,4 @@
-build_platform: {osx_arm64: osx_64}
+build_platform: {osx_arm64: osx_64, win_arm64: win_64}
 conda_forge_output_validation: true
 provider: {linux_aarch64: azure, linux_ppc64le: azure}
 github:

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -5,6 +5,7 @@ rust_arch:
   - aarch64-unknown-linux-gnu   # [aarch64]
   - powerpc64le-unknown-linux-gnu       # [ppc64le]
   - x86_64-pc-windows-msvc      # [win64]
+  - aarch64-pc-windows-msvc     # [win and arm64]
   - x86_64-apple-darwin         # [osx and x86_64]
   - aarch64-apple-darwin        # [osx and arm64]
 

--- a/recipe/install-rust.sh
+++ b/recipe/install-rust.sh
@@ -19,6 +19,7 @@ case "$target_platform" in
     linux-aarch64) rust_env_arch=AARCH64_UNKNOWN_LINUX_GNU ;;
     linux-ppc64le) rust_env_arch=POWERPC64LE_UNKNOWN_LINUX_GNU ;;
     win-64) rust_env_arch=X86_64_PC_WINDOWS_MSVC ;;
+    win-arm64) rust_env_arch=AARCH64_PC_WINDOWS_MSVC ;;
     osx-64) rust_env_arch=X86_64_APPLE_DARWIN ;;
     osx-arm64) rust_env_arch=AARCH64_APPLE_DARWIN ;;
     *) echo "unknown target_platform $target_platform" ; exit 1 ;;

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,6 +21,8 @@ source:
     sha256: 49b6d36b308addcfd21ae56c94957688338ba7b8985bff57fc626c8e1b32f62c  # [osx and arm64]
   - url: https://static.rust-lang.org/dist/rust-{{ version }}-x86_64-pc-windows-msvc.tar.gz  # [win64]
     sha256: b5fac89899343fbc1b8438ff87b77cddaed90a75873db7b01f2c197a26ec9d52  # [win64]
+  - url: https://static.rust-lang.org/dist/rust-{{ version }}-aarch64-pc-windows-msvc.tar.gz  # [win and arm64]
+    sha256: 2f2c4b504fb341fe09407befcb614f041eb45d3795b011322b8bb42674b3c4ea  # [win and arm64]
     patches:
       - 0001-gh-106-install.sh-Perfomance-Use-more-shell-builtins.diff
   # End of block of primary source files.
@@ -60,6 +62,9 @@ source:
   - url: https://static.rust-lang.org/dist/rust-std-{{ version }}-wasm32-unknown-emscripten.tar.gz  # [(linux or win) and x86_64]
     sha256: b61443ca7dd871d92c942aafae677e0ce689b3ac835ab0c7bb101e021132fbb5  # [(linux or win) and x86_64]
     folder: rust-std  # [(linux or win) and x86_64]
+  - url: https://static.rust-lang.org/dist/rust-std-{{ version }}-aarch64-pc-windows-msvc.tar.xz  # [win and arm64]
+    sha256: d96cf028593374741696bf7319198ecb4ee0de2b4f1a72f9ce0c515be3c670bd  # [win and arm64]
+    folder: rust-std # [win and arm64]
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -3,6 +3,7 @@
 package:
   name: rust-split
   version: {{ version }}
+  build: 1
 
 source:
   # Note! This source file specification is structured specifically to interact

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -64,7 +64,7 @@ source:
     folder: rust-std  # [(linux or win) and x86_64]
   - url: https://static.rust-lang.org/dist/rust-std-{{ version }}-aarch64-pc-windows-msvc.tar.xz  # [win and arm64]
     sha256: d96cf028593374741696bf7319198ecb4ee0de2b4f1a72f9ce0c515be3c670bd  # [win and arm64]
-    folder: rust-std # [win and arm64]
+    folder: rust-std  # [win and arm64]
 
 build:
   number: 1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -62,9 +62,9 @@ source:
   - url: https://static.rust-lang.org/dist/rust-std-{{ version }}-wasm32-unknown-emscripten.tar.gz  # [(linux or win) and x86_64]
     sha256: b61443ca7dd871d92c942aafae677e0ce689b3ac835ab0c7bb101e021132fbb5  # [(linux or win) and x86_64]
     folder: rust-std  # [(linux or win) and x86_64]
-  - url: https://static.rust-lang.org/dist/rust-std-{{ version }}-aarch64-pc-windows-msvc.tar.xz  # [win and arm64]
-    sha256: d96cf028593374741696bf7319198ecb4ee0de2b4f1a72f9ce0c515be3c670bd  # [win and arm64]
-    folder: rust-std  # [win and arm64]
+  - url: https://static.rust-lang.org/dist/rust-std-{{ version }}-aarch64-pc-windows-msvc.tar.xz  # [(linux or win) and x86_64]
+    sha256: d96cf028593374741696bf7319198ecb4ee0de2b4f1a72f9ce0c515be3c670bd  # [(linux or win) and x86_64]
+    folder: rust-std  # [(linux or win) and x86_64]
 
 build:
   number: 1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -3,8 +3,7 @@
 package:
   name: rust-split
   version: {{ version }}
-  build: 1
-
+  
 source:
   # Note! This source file specification is structured specifically to interact
   # well with the autotick bot. Importantly, the `patches:` block actually
@@ -68,7 +67,7 @@ source:
     folder: rust-std # [win and arm64]
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:


### PR DESCRIPTION
This PR adds support for `aarch64-pc-windows-msvc`. I took the implementation mostly from https://github.com/conda-forge/rust-feedstock/issues/207 . I dont think the `posix` thing missing for `win-arm64` (as mentioned in the issue) is a big thing because we are cross compiling from `win-64` anyway where the `posix` package is available. But I could be wrong so lets see what CI does. 😄 

Fixes #207