### PR TITLE
add `aarch64-pc-windows-msvc` to `rust_std_extra`

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -21,3 +21,4 @@ rust_std_extra:
   - wasm32-unknown-emscripten
   - x86_64-linux-android
   - x86_64-pc-windows-msvc   # [linux and x86_64]
+  - aarch64-pc-windows-msvc  # [linux and x86_64]


### PR DESCRIPTION
Add `aarch64-pc-windows-msvc` to `rust_std_extra` to build `rust-std-aarch64-pc-windows-msvc` for unix. This will allow cross-compiling to `aarch64-pc-windows-msvc`.