### PR TITLE
Remove rust-analyzer from rust package

### DIFF
--- a/recipe/install-rust.sh
+++ b/recipe/install-rust.sh
@@ -16,6 +16,10 @@ rm -rf "${PREFIX}"/share/doc/rust/json
 rm -f "${PREFIX}"/lib/rustlib/manifest-rust-docs
 rm -f "${PREFIX}"/lib/rustlib/manifest-rust-docs-json-preview
 
+# Remove rust-analyzer - it is not needed for standard Rust compilation
+rm -f "${PREFIX}"/bin/rust-analyzer
+rm -f "${PREFIX}"/lib/rustlib/manifest-rust-analyzer
+
 # Fun times -- by default, Rust/Cargo tries to link executables on Linux by
 # invoking `cc`. An executable of this name is not necessarily available. By
 # setting a magic environment variable, we can override this default.

--- a/recipe/install-rust.sh
+++ b/recipe/install-rust.sh
@@ -18,6 +18,7 @@ rm -f "${PREFIX}"/lib/rustlib/manifest-rust-docs-json-preview
 
 # Remove rust-analyzer - it is not needed for standard Rust compilation
 rm -f "${PREFIX}"/bin/rust-analyzer
+rm -f "${PREFIX}"/bin/rust-analyzer.pdb
 rm -f "${PREFIX}"/lib/rustlib/manifest-rust-analyzer
 
 # Fun times -- by default, Rust/Cargo tries to link executables on Linux by

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -67,7 +67,7 @@ source:
     folder: rust-std  # [(linux or win) and x86_64]
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -157,6 +157,7 @@ outputs:
         # rust-analyzer should not be in the rust package
         - test ! -f "${PREFIX}"/bin/rust-analyzer  # [unix]
         - if exist %LIBRARY_PREFIX%\bin\rust-analyzer.exe exit 1  # [win]
+        - if exist %LIBRARY_PREFIX%\bin\rust-analyzer.pdb exit 1  # [win]
 
   - name: rust-src
     script: install-rust-src.sh  # [unix]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -154,6 +154,9 @@ outputs:
         - test ! -d "${PREFIX}"/share/doc/rust/json  # [unix]
         - if exist %LIBRARY_PREFIX%\share\doc\rust\html exit 1  # [win]
         - if exist %LIBRARY_PREFIX%\share\doc\rust\json exit 1  # [win]
+        # rust-analyzer should not be in the rust package
+        - test ! -f "${PREFIX}"/bin/rust-analyzer  # [unix]
+        - if exist %LIBRARY_PREFIX%\bin\rust-analyzer.exe exit 1  # [win]
 
   - name: rust-src
     script: install-rust-src.sh  # [unix]


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

rust-analyzer takes up ~37MB (~4% of the package size) and follows its own update schedule, receiving updates more frequently than the main Rust release cycle. Since it's not required for standard Rust compilation, it should not be bundled with the core toolchain.

This change:
- Removes rust-analyzer binary and manifest from the rust package
- Adds tests to verify rust-analyzer is not present

Closes #270