### PR TITLE
fix: add quoting for CARGO_TARGET

### DIFF
--- a/recipe/install-rust.sh
+++ b/recipe/install-rust.sh
@@ -41,7 +41,7 @@ if [[ "$target_platform" == linux* ]]; then
     mkdir -p $PREFIX/etc/conda/activate.d $PREFIX/etc/conda/deactivate.d
 
     cat <<EOF >$PREFIX/etc/conda/activate.d/rust.sh
-export CARGO_TARGET_${rust_env_arch}_LINKER=$CC
+export CARGO_TARGET_${rust_env_arch}_LINKER="$CC"
 EOF
 
     cat <<EOF >$PREFIX/etc/conda/deactivate.d/rust.sh

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -70,7 +70,7 @@ source:
     folder: rust-std  # [(linux or win) and x86_64]
 
 build:
-  number: 1
+  number: 2
 
 requirements:
   build:


### PR DESCRIPTION
I've noticed that paths with `&` inside them fail otherwise

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
